### PR TITLE
MockingBird MT support (experimental)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 ---
 
 ## master
+* Adding support for multithreaded tests (experimental, only mock calls are supported from different thread)
+* Fixed Expected , actual reversed
+* Fixed issue where `threadedTest` was running the body twice
 
 ## 1.0.0
 

--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -3,10 +3,39 @@ object Deps {
     private const val kotlinVersion = "1.3.71"
 
     val kotlin = Kotlin
+    val kotlinx = Kotlinx
+    val touchlab = TouchLab
 
     // Jacoco
     const val jacocoVersion = "0.8.5"
     const val jacoco = "org.jacoco:org.jacoco.core:$jacocoVersion"
+
+    object TouchLab {
+        val stately = Stately
+
+        object Stately {
+            private const val statelyVersion = "1.0.3-a4"
+
+            val isolate = Isolate
+
+            object Isolate {
+                const val common = "co.touchlab:stately-isolate:$statelyVersion"
+            }
+        }
+    }
+
+    object Kotlinx {
+        val atomicfu = AtomicFu
+
+        object AtomicFu {
+            private const val atomicFuVersion = "0.14.2"
+            const val plugin = "org.jetbrains.kotlinx:atomicfu-gradle-plugin:$atomicFuVersion"
+
+            const val common = "org.jetbrains.kotlinx:atomicfu-common:$atomicFuVersion"
+            const val jvm = "org.jetbrains.kotlinx:atomicfu:$atomicFuVersion"
+            const val native = "org.jetbrains.kotlinx:atomicfu-native:$atomicFuVersion"
+        }
+    }
 
     object Kotlin {
         val stdlib = Stdlib()

--- a/mockingbird/build.gradle
+++ b/mockingbird/build.gradle
@@ -13,6 +13,8 @@ kotlin {
             dependencies {
                 implementation Deps.kotlin.stdlib.common
                 implementation Deps.kotlin.stdlib
+                implementation Deps.kotlinx.atomicfu.common
+                implementation Deps.touchlab.stately.isolate.common
                 implementation kotlin('test')
                 implementation kotlin('test-common')
                 implementation kotlin('test-annotations-common')
@@ -22,11 +24,13 @@ kotlin {
         jvmMain {
             dependencies {
                 implementation Deps.kotlin.stdlib.jdk8
+                implementation Deps.kotlinx.atomicfu.jvm
             }
         }
 
         iosX64Main {
             dependencies {
+                implementation Deps.kotlinx.atomicfu.native
             }
         }
 

--- a/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/Helpers.kt
+++ b/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/Helpers.kt
@@ -1,0 +1,16 @@
+package com.careem.mockingbird.test
+
+/**
+ * Method to freeze state. Calls the platform implementation of 'freeze' on native, and is a noop on other platforms.
+ */
+expect fun <T> T.freeze(): T
+
+/**
+ * Determine if object is frozen. Will return false on non-native platforms.
+ */
+expect val <T> T.isFrozen: Boolean
+
+/**
+ * Call on an object which should never be frozen. Will help debug when something inadvertently is.
+ */
+expect fun Any.ensureNeverFrozen()

--- a/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/InvocationRecorder.kt
+++ b/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/InvocationRecorder.kt
@@ -1,6 +1,11 @@
 package com.careem.mockingbird.test
 
 internal class InvocationRecorder {
+
+    init {
+        ensureNeverFrozen()
+    }
+
     private val recorder = mutableMapOf<Int, MutableList<Invocation>>()
     private val responses = mutableMapOf<Int, MutableMap<Invocation, (Invocation) -> Any?>>()
 

--- a/mockingbird/src/iosX64Main/kotlin/com/careem/mockingbird/test/Helpers.kt
+++ b/mockingbird/src/iosX64Main/kotlin/com/careem/mockingbird/test/Helpers.kt
@@ -1,0 +1,12 @@
+package com.careem.mockingbird.test
+
+import kotlin.native.concurrent.ensureNeverFrozen
+import kotlin.native.concurrent.freeze
+import kotlin.native.concurrent.isFrozen
+
+actual fun <T> T.freeze(): T = this.freeze()
+
+actual val <T> T.isFrozen: Boolean
+    get() = this.isFrozen
+
+actual fun Any.ensureNeverFrozen() = this.ensureNeverFrozen()

--- a/mockingbird/src/iosX64Main/kotlin/com/careem/mockingbird/test/threadedTest.kt
+++ b/mockingbird/src/iosX64Main/kotlin/com/careem/mockingbird/test/threadedTest.kt
@@ -5,11 +5,8 @@ import kotlin.native.concurrent.Worker
 import kotlin.native.concurrent.freeze
 
 actual fun <T> threadedTest(body: () -> T): T {
-    body()
-
-    body.freeze()
     val worker = Worker.start()
-    val future = worker.execute(TransferMode.SAFE, { body }) {
+    val future = worker.execute(TransferMode.SAFE, { body.freeze() }) {
         println("Running body in worker")
         runCatching(it)
     }

--- a/mockingbird/src/jvmMain/kotlin/com/careem/mockingbird/test/Helpers.kt
+++ b/mockingbird/src/jvmMain/kotlin/com/careem/mockingbird/test/Helpers.kt
@@ -1,0 +1,8 @@
+package com.careem.mockingbird.test
+
+actual fun <T> T.freeze(): T = this
+
+actual val <T> T.isFrozen: Boolean
+    get() = false
+
+actual fun Any.ensureNeverFrozen() {}


### PR DESCRIPTION
* Update mockingbird to support MT mocking ( only mock invocation on different thread is supported, `every` `everyAnswer` and `verify` must be called from test thread )