### PR TITLE
Support for CapturedSlots and CapturedLists for LocalThread mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ## master
 * Added support to capture objects and lists while running a test with LOCAL_THREAD mode
+* **[DEPRECATED]** `Slot()` use `slot()` instead
+* **[DEPRECATED]** `CapturedList()` use `capturedList()` instead
 
 ## 1.13.0
 * **breaking** If there are multiple mocked responses matching a mock invocation, the one that was added last will be used

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ---
 
 ## master
+* Added support to capture objects and lists while running a test with LOCAL_THREAD mode
 
 ## 1.13.0
 * **breaking** If there are multiple mocked responses matching a mock invocation, the one that was added last will be used

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ arguments.
 To do matching, you will use:
 
 1. `any()`
-2. `Slot` and `capture`
+2. `slot()` and `capture`
 
 #### Any
 
@@ -289,12 +289,12 @@ A normal use case on verify with `any()` matcher is verify invocation is invoked
 
 Another use case for matching is: for example you want to verify `myDependencyMock.method4(object1)`
 is invoked, but the reference of object1 is not mocked or initiated inside the test case, In this case, an easy way to
-verify, or say matching arguments, is create a object `Slot` or `CapturedList` and then
+verify, or say matching arguments, is create an object using `slot()` or `capturedList()` and then
 `capture` this object when verify the invocation, something like:
 
 ```kotlin
-val objectSlot = Slot<Object>()
-val objectCapturedList = CapturedList<Object>()
+val objectSlot = slot<Object>()
+val objectCapturedList = capturedList<Object>()
 
 testMock.every(
     methodName = MyDependencyMock.Method.method1,

--- a/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/Capture.kt
+++ b/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/Capture.kt
@@ -98,14 +98,13 @@ public fun <T> slot(): Slot<T> {
     }
 }
 
-
 public interface CapturedList<T> : Captureable {
     public val captured: List<T>
 }
 
 @Deprecated(
     message = "Use different function call instead",
-    replaceWith = ReplaceWith("capturedList()", "com.careem.mockingbird.test.slot")
+    replaceWith = ReplaceWith("capturedList()", "com.careem.mockingbird.test.capturedList")
 )
 /**
  * A list that using to fetch the method invocation and compare the property inside
@@ -116,6 +115,11 @@ public fun <T> CapturedList(): CapturedList<T> {
     return capturedList()
 }
 
+/**
+ * A list that using to fetch the method invocation and compare the property inside
+ * invocation arguments
+ * Usage example @see [FunctionsTest]
+ */
 public fun <T> capturedList(): CapturedList<T> {
     return when (MockingBird.mode) {
         TestMode.MULTI_THREAD -> ThreadSafeCapturedList()

--- a/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/Capture.kt
+++ b/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/Capture.kt
@@ -46,16 +46,27 @@ public fun <T> capture(list: CapturedList<T>): CapturedMatcher<T> {
 /**
  * A slot using to fetch the method invocation and compare the property inside invocation arguments
  * Usage example @see [FunctionsTest]
- *
  */
+
+public class Slot<T> : Captureable {
+
+    private val genericSlot : GenereicSlot<T> = initializeSlot<T>()
+
+    public val captured: T?
+        get() {
+            return genericSlot.value
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun storeCapturedValue(value: Any?) {
+        genericSlot.storeCapturedValue(value)
+    }
+}
 
 private fun <T> initializeSlot(): GenereicSlot<T> {
     return when (MockingBird.mode) {
-        TestMode.MULTI_THREAD -> MultiThreadSlot<T>()
-        TestMode.LOCAL_THREAD -> LocalThreadSlot<T>()
-//        TestMode.LOCAL_THREAD -> {
-//            TODO()
-//        }
+        TestMode.MULTI_THREAD -> MultiThreadSlot()
+        TestMode.LOCAL_THREAD -> LocalThreadSlot()
     }
 }
 
@@ -91,21 +102,6 @@ private class LocalThreadSlot<T> : GenereicSlot<T> {
     @Suppress("UNCHECKED_CAST")
     override fun storeCapturedValue(value: Any?) {
         this.value = value as T
-    }
-}
-
-public class Slot<T> : Captureable {
-
-    private val genericSlot : GenereicSlot<T> = initializeSlot<T>()
-
-    public val captured: T?
-        get() {
-          return genericSlot.value
-        }
-
-    @Suppress("UNCHECKED_CAST")
-    override fun storeCapturedValue(value: Any?) {
-        genericSlot.storeCapturedValue(value)
     }
 }
 

--- a/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/Capture.kt
+++ b/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/Capture.kt
@@ -75,15 +75,14 @@ private class ThreadSafeSlot<T> : GenericSlot<T> {
 
     private val _captured: AtomicRef<T?> = atomic(null)
 
+    override val value: T?
+        get() = _captured.value
+
     @Suppress("UNCHECKED_CAST")
     override fun storeCapturedValue(value: Any?) {
         _captured.value = value as T
     }
-
-    override val value: T?
-        get() = _captured.value
 }
-
 
 private class LocalThreadSlot<T> : GenericSlot<T> {
 

--- a/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/Capture.kt
+++ b/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/Capture.kt
@@ -108,19 +108,6 @@ private class LocalThreadSlot<T> : GenericSlot<T> {
  * invocation arguments
  * Usage example @see [FunctionsTest]
  */
-//public class CapturedList<T> : Captureable {
-//    private val _captured = IsolateState { mutableListOf<T>() }
-//    public val captured: List<T>
-//        get() {
-//            return _captured.access { it.toList() }
-//        }
-//
-//    @Suppress("UNCHECKED_CAST")
-//    override fun storeCapturedValue(value: Any?) {
-//        _captured.access { it.add(value as T) }
-//    }
-//}
-
 public class CapturedList<T> : Captureable {
 
     private val genericCaptureList = initializeGenericCaptureList<T>()
@@ -135,11 +122,11 @@ public class CapturedList<T> : Captureable {
     }
 }
 
-private interface GenericCaptureList<T> : Captureable {
+private interface GenericCapturedList<T> : Captureable {
     val value: List<T>
 }
 
-private class MultiThreadCaptureList<T> : GenericCaptureList<T> {
+private class MultiThreadCapturedList<T> : GenericCapturedList<T> {
 
     private val _captured = IsolateState { mutableListOf<T>() }
 
@@ -154,24 +141,21 @@ private class MultiThreadCaptureList<T> : GenericCaptureList<T> {
     }
 }
 
-
-private fun <T> initializeGenericCaptureList(): GenericCaptureList<T> {
+private fun <T> initializeGenericCaptureList(): GenericCapturedList<T> {
     return when (MockingBird.mode) {
-        TestMode.MULTI_THREAD -> MultiThreadCaptureList()
-        TestMode.LOCAL_THREAD -> LocalThreadCaptureList()
+        TestMode.MULTI_THREAD -> MultiThreadCapturedList()
+        TestMode.LOCAL_THREAD -> LocalThreadCapturedList()
     }
 }
 
+private class LocalThreadCapturedList<T> : GenericCapturedList<T> {
 
-private class LocalThreadCaptureList<T> : GenericCaptureList<T> {
+    private val _captured = mutableListOf<T>()
 
-    private val _captured =   mutableListOf<T>()
-
-    public override val value: List<T>
+    override val value: List<T>
         get() {
             return _captured.toList()
         }
-
 
     @Suppress("UNCHECKED_CAST")
     override fun storeCapturedValue(value: Any?) {

--- a/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/Capture.kt
+++ b/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/Capture.kt
@@ -14,8 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress("NON_EXHAUSTIVE_WHEN")
-
 package com.careem.mockingbird.test
 
 import co.touchlab.stately.isolate.IsolateState
@@ -50,31 +48,30 @@ public fun <T> capture(list: CapturedList<T>): CapturedMatcher<T> {
 
 public class Slot<T> : Captureable {
 
-    private val genericSlot : GenereicSlot<T> = initializeSlot<T>()
+    private val genericSlot : GenericSlot<T> = initializeSlot()
 
     public val captured: T?
         get() {
             return genericSlot.value
         }
 
-    @Suppress("UNCHECKED_CAST")
     override fun storeCapturedValue(value: Any?) {
         genericSlot.storeCapturedValue(value)
     }
 }
 
-private fun <T> initializeSlot(): GenereicSlot<T> {
+private fun <T> initializeSlot(): GenericSlot<T> {
     return when (MockingBird.mode) {
-        TestMode.MULTI_THREAD -> MultiThreadSlot()
+        TestMode.MULTI_THREAD -> ThreadSafeSlot()
         TestMode.LOCAL_THREAD -> LocalThreadSlot()
     }
 }
 
-private interface GenereicSlot<T> : Captureable {
-    val value: T?
+public interface GenericSlot<T> : Captureable {
+    public val value: T?
 }
 
-private class MultiThreadSlot<T> : GenereicSlot<T> {
+private class ThreadSafeSlot<T> : GenericSlot<T> {
 
     private val _captured: AtomicRef<T?> = atomic(null)
 
@@ -87,7 +84,8 @@ private class MultiThreadSlot<T> : GenereicSlot<T> {
         get() = _captured.value
 }
 
-private class LocalThreadSlot<T> : GenereicSlot<T> {
+
+private class LocalThreadSlot<T> : GenericSlot<T> {
 
     private var _captured: T? = null
 

--- a/mockingbird/src/commonTest/kotlin/com/careem/mockingbird/test/FreezeStateVerification.kt
+++ b/mockingbird/src/commonTest/kotlin/com/careem/mockingbird/test/FreezeStateVerification.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright Careem, an Uber Technologies Inc. company
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.careem.mockingbird.test
+
+
+expect fun <T> T.verifyFreezeStateForMultiThread()
+
+expect fun <T> T.verifyFreezeStateForLocalThread()

--- a/mockingbird/src/commonTest/kotlin/com/careem/mockingbird/test/FreezeStateVerification.kt
+++ b/mockingbird/src/commonTest/kotlin/com/careem/mockingbird/test/FreezeStateVerification.kt
@@ -16,7 +16,6 @@
 
 package com.careem.mockingbird.test
 
-
 expect fun <T> T.verifyFreezeStateForMultiThread()
 
 expect fun <T> T.verifyFreezeStateForLocalThread()

--- a/mockingbird/src/commonTest/kotlin/com/careem/mockingbird/test/FunctionsTest.kt
+++ b/mockingbird/src/commonTest/kotlin/com/careem/mockingbird/test/FunctionsTest.kt
@@ -145,7 +145,7 @@ class FunctionsTest {
     @Test
     fun testCaptureSlotWithCorrectArgument() {
         val testMock = MyDependencyMock()
-        val stringSlot = Slot<String>()
+        val stringSlot = slot<String>()
         testMock.every(
             methodName = MyDependencyMock.Method.method1,
             arguments = mapOf(MyDependencyMock.Arg.str to TEST_STRING)
@@ -162,8 +162,32 @@ class FunctionsTest {
     }
 
     @Test
-    fun testCaptureLocalSlotWithCorrectArgument() = runWithTestMode(TestMode.LOCAL_THREAD) {
+    fun testCaptureSlotWithCorrectArgumentDeprecated() {
         val testMock = MyDependencyMock()
+
+        @Suppress("DEPRECATION")
+        val stringSlot = Slot<String>()
+        testMock.every(
+            methodName = MyDependencyMock.Method.method1,
+            arguments = mapOf(MyDependencyMock.Arg.str to TEST_STRING)
+        ) {}
+
+        testMock.method1(TEST_STRING)
+        testMock.verify(
+            methodName = MyDependencyMock.Method.method1,
+            arguments = mapOf(MyDependencyMock.Arg.str to capture(stringSlot))
+        )
+
+        assertEquals(TEST_STRING, stringSlot.captured)
+        stringSlot.verifyFreezeStateForMultiThread()
+    }
+
+
+    @Test
+    fun testCaptureLocalSlotWithCorrectArgumentDeprecated() = runWithTestMode(TestMode.LOCAL_THREAD) {
+        val testMock = MyDependencyMock()
+
+        @Suppress("DEPRECATION")
         val stringSlot = Slot<String>()
 
         testMock.every(
@@ -180,9 +204,32 @@ class FunctionsTest {
         stringSlot.verifyFreezeStateForLocalThread()
     }
 
+
     @Test
-    fun testCaptureSlotWithWrongArgument() {
+    fun testCaptureLocalSlotWithCorrectArgument() = runWithTestMode(TestMode.LOCAL_THREAD) {
         val testMock = MyDependencyMock()
+
+        val stringSlot = slot<String>()
+
+        testMock.every(
+            methodName = MyDependencyMock.Method.method1,
+            arguments = mapOf(MyDependencyMock.Arg.str to TEST_STRING)
+        ) {}
+
+        testMock.method1(TEST_STRING)
+        testMock.verify(
+            methodName = MyDependencyMock.Method.method1,
+            arguments = mapOf(MyDependencyMock.Arg.str to capture(stringSlot))
+        )
+        assertEquals(TEST_STRING, stringSlot.captured)
+        stringSlot.verifyFreezeStateForLocalThread()
+    }
+
+    @Test
+    fun testCaptureSlotWithWrongArgumentDeprecated() {
+        val testMock = MyDependencyMock()
+
+        @Suppress("DEPRECATION")
         val stringSlot = Slot<String>()
         testMock.every(
             methodName = MyDependencyMock.Method.method1,
@@ -197,6 +244,29 @@ class FunctionsTest {
             )
         } catch (error: AssertionError) {
             assertNotNull(error)
+            stringSlot.verifyFreezeStateForMultiThread()
+        }
+    }
+
+    @Test
+    fun testCaptureSlotWithWrongArgument() {
+        val testMock = MyDependencyMock()
+
+        val stringSlot = slot<String>()
+        testMock.every(
+            methodName = MyDependencyMock.Method.method1,
+            arguments = mapOf(MyDependencyMock.Arg.str to TEST_STRING)
+        ) {}
+
+        try {
+            testMock.method1(TEST_STRING)
+            testMock.verify(
+                methodName = MyDependencyMock.Method.method1,
+                arguments = mapOf(MyDependencyMock.Arg.value to capture(stringSlot))
+            )
+        } catch (error: AssertionError) {
+            assertNotNull(error)
+            stringSlot.verifyFreezeStateForMultiThread()
         }
     }
 

--- a/mockingbird/src/commonTest/kotlin/com/careem/mockingbird/test/FunctionsTest.kt
+++ b/mockingbird/src/commonTest/kotlin/com/careem/mockingbird/test/FunctionsTest.kt
@@ -221,6 +221,31 @@ class FunctionsTest {
         assertEquals(TEST_STRING, capturedList.captured[0])
         assertEquals(TEST_STRING, capturedList.captured[1])
         assertEquals(TEST_STRING, capturedList.captured[2])
+        capturedList.verifyFreezeStateForMultiThread()
+    }
+
+    @Test
+    fun testCapturedListSucceedOnLocalThread()= runWithTestMode(TestMode.LOCAL_THREAD) {
+        val testMock = MyDependencyMock()
+        val capturedList = CapturedList<String>()
+        testMock.every(
+            methodName = MyDependencyMock.Method.method1,
+            arguments = mapOf(MyDependencyMock.Arg.str to TEST_STRING)
+        ) {}
+
+        testMock.method1(TEST_STRING)
+        testMock.method1(TEST_STRING)
+        testMock.method1(TEST_STRING)
+        testMock.verify(
+            exactly = 3,
+            methodName = MyDependencyMock.Method.method1,
+            arguments = mapOf(MyDependencyMock.Arg.str to capture(capturedList))
+        )
+        assertEquals(3, capturedList.captured.size)
+        assertEquals(TEST_STRING, capturedList.captured[0])
+        assertEquals(TEST_STRING, capturedList.captured[1])
+        assertEquals(TEST_STRING, capturedList.captured[2])
+        capturedList.verifyFreezeStateForLocalThread()
     }
 
     @Test

--- a/mockingbird/src/commonTest/kotlin/com/careem/mockingbird/test/FunctionsTest.kt
+++ b/mockingbird/src/commonTest/kotlin/com/careem/mockingbird/test/FunctionsTest.kt
@@ -271,8 +271,10 @@ class FunctionsTest {
     }
 
     @Test
-    fun testCapturedListSucceed() {
+    fun testCapturedListSucceedDeprecated() {
         val testMock = MyDependencyMock()
+
+        @Suppress("DEPRECATION")
         val capturedList = CapturedList<String>()
         testMock.every(
             methodName = MyDependencyMock.Method.method1,
@@ -295,9 +297,59 @@ class FunctionsTest {
     }
 
     @Test
-    fun testCapturedListSucceedOnLocalThread()= runWithTestMode(TestMode.LOCAL_THREAD) {
+    fun testCapturedListSucceed() {
         val testMock = MyDependencyMock()
+
+        val capturedList = capturedList<String>()
+        testMock.every(
+            methodName = MyDependencyMock.Method.method1,
+            arguments = mapOf(MyDependencyMock.Arg.str to TEST_STRING)
+        ) {}
+
+        testMock.method1(TEST_STRING)
+        testMock.method1(TEST_STRING)
+        testMock.method1(TEST_STRING)
+        testMock.verify(
+            exactly = 3,
+            methodName = MyDependencyMock.Method.method1,
+            arguments = mapOf(MyDependencyMock.Arg.str to capture(capturedList))
+        )
+        assertEquals(3, capturedList.captured.size)
+        assertEquals(TEST_STRING, capturedList.captured[0])
+        assertEquals(TEST_STRING, capturedList.captured[1])
+        assertEquals(TEST_STRING, capturedList.captured[2])
+        capturedList.verifyFreezeStateForMultiThread()
+    }
+
+    @Test
+    fun testCapturedListSucceedOnLocalThreadDeprecated() = runWithTestMode(TestMode.LOCAL_THREAD) {
+        val testMock = MyDependencyMock()
+        @Suppress("DEPRECATION")
         val capturedList = CapturedList<String>()
+        testMock.every(
+            methodName = MyDependencyMock.Method.method1,
+            arguments = mapOf(MyDependencyMock.Arg.str to TEST_STRING)
+        ) {}
+
+        testMock.method1(TEST_STRING)
+        testMock.method1(TEST_STRING)
+        testMock.method1(TEST_STRING)
+        testMock.verify(
+            exactly = 3,
+            methodName = MyDependencyMock.Method.method1,
+            arguments = mapOf(MyDependencyMock.Arg.str to capture(capturedList))
+        )
+        assertEquals(3, capturedList.captured.size)
+        assertEquals(TEST_STRING, capturedList.captured[0])
+        assertEquals(TEST_STRING, capturedList.captured[1])
+        assertEquals(TEST_STRING, capturedList.captured[2])
+        capturedList.verifyFreezeStateForLocalThread()
+    }
+
+    @Test
+    fun testCapturedListSucceedOnLocalThread() = runWithTestMode(TestMode.LOCAL_THREAD) {
+        val testMock = MyDependencyMock()
+        val capturedList = capturedList<String>()
         testMock.every(
             methodName = MyDependencyMock.Method.method1,
             arguments = mapOf(MyDependencyMock.Arg.str to TEST_STRING)

--- a/mockingbird/src/commonTest/kotlin/com/careem/mockingbird/test/FunctionsTest.kt
+++ b/mockingbird/src/commonTest/kotlin/com/careem/mockingbird/test/FunctionsTest.kt
@@ -159,6 +159,25 @@ class FunctionsTest {
         assertEquals(TEST_STRING, stringSlot.captured)
     }
 
+    //TODO verify that the slot is a LocalThreadSlot
+    @Test
+    fun testCaptureLocalSlotWithCorrectArgument() = runWithTestMode(TestMode.LOCAL_THREAD) {
+        val testMock = MyDependencyMock()
+        val stringSlot = Slot<String>()
+
+        testMock.every(
+            methodName = MyDependencyMock.Method.method1,
+            arguments = mapOf(MyDependencyMock.Arg.str to TEST_STRING)
+        ) {}
+
+        testMock.method1(TEST_STRING)
+        testMock.verify(
+            methodName = MyDependencyMock.Method.method1,
+            arguments = mapOf(MyDependencyMock.Arg.str to capture(stringSlot))
+        )
+        assertEquals(TEST_STRING, stringSlot.captured)
+    }
+
     @Test
     fun testCaptureSlotWithWrongArgument() {
         val testMock = MyDependencyMock()

--- a/mockingbird/src/commonTest/kotlin/com/careem/mockingbird/test/FunctionsTest.kt
+++ b/mockingbird/src/commonTest/kotlin/com/careem/mockingbird/test/FunctionsTest.kt
@@ -156,10 +156,11 @@ class FunctionsTest {
             methodName = MyDependencyMock.Method.method1,
             arguments = mapOf(MyDependencyMock.Arg.str to capture(stringSlot))
         )
+
         assertEquals(TEST_STRING, stringSlot.captured)
+        stringSlot.verifyFreezeStateForMultiThread()
     }
 
-    //TODO verify that the slot is a LocalThreadSlot
     @Test
     fun testCaptureLocalSlotWithCorrectArgument() = runWithTestMode(TestMode.LOCAL_THREAD) {
         val testMock = MyDependencyMock()
@@ -176,6 +177,7 @@ class FunctionsTest {
             arguments = mapOf(MyDependencyMock.Arg.str to capture(stringSlot))
         )
         assertEquals(TEST_STRING, stringSlot.captured)
+        stringSlot.verifyFreezeStateForLocalThread()
     }
 
     @Test

--- a/mockingbird/src/iosX64Test/kotlin/com/careem/mockingbird/test/FreezeStateVerification.kt
+++ b/mockingbird/src/iosX64Test/kotlin/com/careem/mockingbird/test/FreezeStateVerification.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright Careem, an Uber Technologies Inc. company
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.careem.mockingbird.test
+
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+actual fun <T> T.verifyFreezeStateForMultiThread() {
+    assertTrue { this.isFrozen }
+}
+
+actual fun <T> T.verifyFreezeStateForLocalThread() {
+    assertFalse { this.isFrozen }
+}

--- a/mockingbird/src/jsTest/kotlin/com/careem/mockingbird/test/FreezeStateVerification.kt
+++ b/mockingbird/src/jsTest/kotlin/com/careem/mockingbird/test/FreezeStateVerification.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright Careem, an Uber Technologies Inc. company
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.careem.mockingbird.test
+
+import kotlin.test.assertFalse
+
+actual fun <T> T.verifyFreezeStateForMultiThread() {
+    assertFalse { this.isFrozen }
+}
+
+actual fun <T> T.verifyFreezeStateForLocalThread() {
+    assertFalse { this.isFrozen }
+}

--- a/mockingbird/src/jvmTest/kotlin/com/careem/mockingbird/test/FreezeStateVerification.kt
+++ b/mockingbird/src/jvmTest/kotlin/com/careem/mockingbird/test/FreezeStateVerification.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright Careem, an Uber Technologies Inc. company
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.careem.mockingbird.test
+
+import kotlin.test.assertFalse
+
+actual fun <T> T.verifyFreezeStateForMultiThread() {
+    assertFalse { this.isFrozen }
+}
+
+actual fun <T> T.verifyFreezeStateForLocalThread() {
+    assertFalse { this.isFrozen }
+}


### PR DESCRIPTION
Once lambda was added to a slot the: 
`private val _captured: AtomicRef<T?> = atomic(null)`

was storing it and freezing (due to AtomicRef) even if MockingBird.mode = LocalThread. 

For this reason, for local thread the LocalThreadSlot will be created while for the previous case (multithreaded) we are going the existing approach. 




