### PR TITLE
Bumping KotlinPoet and metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 ---
 
 ## master
+* KotlinPoet to 1.10.2 and addressed breaking changes
+* Kotlin metadata to 0.2.0
 
 ## 2.1.0
 * Fixed issue that was preventing the plugin from been applied in the `plugins` block

--- a/mockingbird-compiler/build.gradle.kts
+++ b/mockingbird-compiler/build.gradle.kts
@@ -51,8 +51,7 @@ dependencies {
     implementation(libs.kotlin.reflectjvm)
     implementation(libs.square.kotlinpoet)
     implementation(libs.square.kotlinpoet.metadata)
-    implementation(libs.square.kotlinpoet.metadata.specs)
-    implementation(libs.kotlinx.metadatajvm)
+    implementation(libs.kotlinx.metadata.jvm)
     implementation(project(":mockingbird"))
 
     testImplementation(libs.kotlin.test)

--- a/mockingbird-compiler/src/main/kotlin/com/careem/mockingbird/ClassLoaderWrapper.kt
+++ b/mockingbird-compiler/src/main/kotlin/com/careem/mockingbird/ClassLoaderWrapper.kt
@@ -16,10 +16,10 @@
 
 package com.careem.mockingbird
 
-import com.squareup.kotlinpoet.metadata.ImmutableKmClass
-import com.squareup.kotlinpoet.metadata.ImmutableKmType
 import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
+import kotlinx.metadata.KmClass
 import kotlinx.metadata.KmClassifier
+import kotlinx.metadata.KmType
 import org.gradle.api.Project
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
 import org.gradle.api.logging.Logger
@@ -56,9 +56,9 @@ class ClassLoaderWrapper(
     @Throws(ClassNotFoundException::class)
     fun loadClass(name: String): KClass<*> = classLoader.loadClass(name).kotlin
 
-    fun loadClass(kmClass: ImmutableKmType): KClass<*> = loadClassFromDirectory(extractTypeString(kmClass))
+    fun loadClass(kmClass: KmType): KClass<*> = loadClassFromDirectory(extractTypeString(kmClass))
 
-    fun loadClass(kmClass: ImmutableKmClass): KClass<*> = loadClassFromDirectory(kmClass.name)
+    fun loadClass(kmClass: KmClass): KClass<*> = loadClassFromDirectory(kmClass.name)
 
     fun loadClassFromDirectory(path: String): KClass<*> {
         return loadClass(path.toJavaFullyQualifiedName())
@@ -94,7 +94,7 @@ class ClassLoaderWrapper(
         }
     }
 
-    private fun extractTypeString(type: ImmutableKmType): String {
+    private fun extractTypeString(type: KmType): String {
         return if (type.classifier is KmClassifier.Class) {
             (type.classifier as KmClassifier.Class).name
         } else {

--- a/mockingbird-compiler/src/main/kotlin/com/careem/mockingbird/FunctionsMiner.kt
+++ b/mockingbird-compiler/src/main/kotlin/com/careem/mockingbird/FunctionsMiner.kt
@@ -16,12 +16,15 @@
 
 package com.careem.mockingbird
 
-import com.squareup.kotlinpoet.metadata.ImmutableKmClass
-import com.squareup.kotlinpoet.metadata.ImmutableKmFunction
-import com.squareup.kotlinpoet.metadata.ImmutableKmProperty
 import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
-import com.squareup.kotlinpoet.metadata.toImmutableKmClass
+import com.squareup.kotlinpoet.metadata.toKmClass
+import kotlinx.metadata.KmClass
 import kotlinx.metadata.KmClassifier
+import kotlinx.metadata.KmFunction
+import kotlinx.metadata.KmProperty
+import kotlinx.metadata.jvm.getterSignature
+import kotlinx.metadata.jvm.setterSignature
+import kotlinx.metadata.jvm.signature
 
 @Suppress("UnstableApiUsage")
 @KotlinPoetMetadataPreview
@@ -33,9 +36,9 @@ class FunctionsMiner(
      * Extract all functions and properties, this will extract also functions that are defined into the supertypes
      * these functions are all the functions that the mock class should provide
      */
-    fun extractFunctionsAndProperties(kmClass: ImmutableKmClass): Pair<List<ImmutableKmFunction>, List<ImmutableKmProperty>> {
-        val functions: MutableList<ImmutableKmFunction> = mutableListOf()
-        val properties: MutableList<ImmutableKmProperty> = mutableListOf()
+    fun extractFunctionsAndProperties(kmClass: KmClass): Pair<List<KmFunction>, List<KmProperty>> {
+        val functions: MutableList<KmFunction> = mutableListOf()
+        val properties: MutableList<KmProperty> = mutableListOf()
         rawExtractFunctionsAndProperties(kmClass, functions, properties)
         return functions.distinctBy { it.signature } to properties
             .filter { it.getterSignature != null || it.setterSignature != null }
@@ -43,15 +46,15 @@ class FunctionsMiner(
     }
 
     private fun rawExtractFunctionsAndProperties(
-        kmClass: ImmutableKmClass,
-        functions: MutableList<ImmutableKmFunction>,
-        properties: MutableList<ImmutableKmProperty>
+        kmClass: KmClass,
+        functions: MutableList<KmFunction>,
+        properties: MutableList<KmProperty>
     ) { // TODO optimize with tailrec
         val kmSuperTypes = kmClass.supertypes
             .map { it.classifier }
             .filterIsInstance<KmClassifier.Class>()
             .filter { it.name != "kotlin/Any" }
-            .map { classLoaderWrapper.loadClassFromDirectory(it.name).toImmutableKmClass() }
+            .map { classLoaderWrapper.loadClassFromDirectory(it.name).toKmClass() }
 
         // get functions and properties for current class
         functions.addAll(kmClass.functions)

--- a/mockingbird-compiler/src/main/kotlin/com/careem/mockingbird/MockingbirdPlugin.kt
+++ b/mockingbird-compiler/src/main/kotlin/com/careem/mockingbird/MockingbirdPlugin.kt
@@ -15,9 +15,9 @@
  */
 package com.careem.mockingbird
 
-import com.squareup.kotlinpoet.metadata.ImmutableKmClass
 import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
-import com.squareup.kotlinpoet.metadata.toImmutableKmClass
+import com.squareup.kotlinpoet.metadata.toKmClass
+import kotlinx.metadata.KmClass
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.logging.Logger
@@ -98,7 +98,7 @@ abstract class MockingbirdPlugin : Plugin<Project> {
         outputDir.mkdirs()
 
         pluginExtensions.generateMocksFor
-            .map { classLoader.loadClass(it).toImmutableKmClass() }
+            .map { classLoader.loadClass(it).toKmClass() }
             .let { generateClasses(it, outputDir) }
     }
 
@@ -112,7 +112,7 @@ abstract class MockingbirdPlugin : Plugin<Project> {
     }
 
 
-    private fun generateClasses(classNames: List<ImmutableKmClass>, outputDir: File) {
+    private fun generateClasses(classNames: List<KmClass>, outputDir: File) {
         for (kmClass in classNames) {
             mockGenerator.createClass(kmClass).writeTo(outputDir)
         }

--- a/mockingbird-compiler/src/test/kotlin/com/careem/mockingbird/FunctionsMinerTest.kt
+++ b/mockingbird-compiler/src/test/kotlin/com/careem/mockingbird/FunctionsMinerTest.kt
@@ -17,7 +17,7 @@
 package com.careem.mockingbird
 
 import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
-import com.squareup.kotlinpoet.metadata.toImmutableKmClass
+import com.squareup.kotlinpoet.metadata.toKmClass
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Before
@@ -37,7 +37,7 @@ class FunctionsMinerTest {
 
     @Test
     fun testExtractFunctionsAndPropertiesWithSuperInterface() {
-        val (functions, properties) = functionsMiner.extractFunctionsAndProperties(SuperInterface::class.toImmutableKmClass())
+        val (functions, properties) = functionsMiner.extractFunctionsAndProperties(SuperInterface::class.toKmClass())
         assertEquals(2, functions.size)
         assertEquals(0, properties.size)
     }
@@ -45,16 +45,16 @@ class FunctionsMinerTest {
     @Test
     fun testExtractFunctionsAndPropertiesWithChildInterface() {
         every { classLoaderWrapper.loadClassFromDirectory(any()) } returns SuperInterface::class
-        val (functions, properties) = functionsMiner.extractFunctionsAndProperties(ChildInterface::class.toImmutableKmClass())
+        val (functions, properties) = functionsMiner.extractFunctionsAndProperties(ChildInterface::class.toKmClass())
         assertEquals(4, functions.size)
         assertEquals(0, properties.size)
     }
 
     @Test
     fun testExtractFunctionsAndPropertiesWithChildInterfaceImpl() {
-        every { classLoaderWrapper.loadClassFromDirectory(SuperInterface::class.toImmutableKmClass().name) } returns SuperInterface::class
-        every { classLoaderWrapper.loadClassFromDirectory(ChildInterface::class.toImmutableKmClass().name) } returns ChildInterface::class
-        val (functions, properties) = functionsMiner.extractFunctionsAndProperties(ChildInterfaceImpl::class.toImmutableKmClass())
+        every { classLoaderWrapper.loadClassFromDirectory(SuperInterface::class.toKmClass().name) } returns SuperInterface::class
+        every { classLoaderWrapper.loadClassFromDirectory(ChildInterface::class.toKmClass().name) } returns ChildInterface::class
+        val (functions, properties) = functionsMiner.extractFunctionsAndProperties(ChildInterfaceImpl::class.toKmClass())
         assertEquals(4, functions.size)
         assertEquals(2, properties.size)
     }

--- a/versions.toml
+++ b/versions.toml
@@ -4,8 +4,8 @@ junit = "4.13.1"
 jacoco = "0.8.7"
 stately = "1.1.10-a1"
 atomicFu = "0.16.3"
-kotlinPoet = "1.9.0"
-kotlinxMetadata = "0.1.0"
+kotlinPoet = "1.10.2"
+kotlinxMetadata = "0.2.0"
 mockk = "1.12.0"
 
 [libraries]
@@ -20,8 +20,7 @@ junit-junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-reflectjvm = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 square-kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinPoet" }
 square-kotlinpoet-metadata = { module = "com.squareup:kotlinpoet-metadata", version.ref = "kotlinPoet" }
-square-kotlinpoet-metadata-specs = { module = "com.squareup:kotlinpoet-metadata-specs", version.ref = "kotlinPoet" }
-kotlinx-metadatajvm = { module = "org.jetbrains.kotlinx:kotlinx-metadata-jvm", version.ref = "kotlinxMetadata" }
+kotlinx-metadata-jvm = { module = "org.jetbrains.kotlinx:kotlinx-metadata-jvm", version.ref = "kotlinxMetadata" }
 
 kotlinx-atomicfu-gradle = { module = "org.jetbrains.kotlinx:atomicfu-gradle-plugin", version.ref = "atomicFu" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }


### PR DESCRIPTION
* KotlinPoet to 1.10.2, this version remove `ImmutableKm*` and relies directly on kotlin metadata types, addressing here
* Kotlin metadata 0.2.0