### PR TITLE
Try to fix mock address clashes

### DIFF
--- a/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/InvocationRecorder.kt
+++ b/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/InvocationRecorder.kt
@@ -91,6 +91,10 @@ internal class InvocationRecorder {
         }
     }
 
+    fun reset() {
+        recorder.clear()
+    }
+
     /**
      * Helper to find stores response, need to take care of @see [AnyMatcher]
      */

--- a/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/InvocationRecorderProvider.kt
+++ b/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/InvocationRecorderProvider.kt
@@ -18,4 +18,6 @@ package com.careem.mockingbird.test
 
 internal interface InvocationRecorderProvider {
     public fun <R> access(block: (InvocationRecorder) -> R): R
+
+    public fun reset()
 }

--- a/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/IsolateStateInvocationRecorderProvider.kt
+++ b/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/IsolateStateInvocationRecorderProvider.kt
@@ -22,4 +22,6 @@ internal class IsolateStateInvocationRecorderProvider : InvocationRecorderProvid
     private val invocationRecorder = IsolateState { InvocationRecorder() }
 
     override fun <R> access(block: (InvocationRecorder) -> R): R = invocationRecorder.access(block)
+
+    public override fun reset() = invocationRecorder.access { it.reset() }
 }

--- a/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/MockingBird.kt
+++ b/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/MockingBird.kt
@@ -53,6 +53,8 @@ internal object MockingBird {
      */
     internal fun reset() {
         state.value = DEFAULT_STATE
+        localInvocationRecorder.reset()
+        mtInvocationRecorder.reset()
     }
 
     internal fun invocationRecorder(): InvocationRecorderProvider {

--- a/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/SimpleInvocationRecorderProvider.kt
+++ b/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/SimpleInvocationRecorderProvider.kt
@@ -21,4 +21,6 @@ internal class SimpleInvocationRecorderProvider : InvocationRecorderProvider {
     private val invocationRecorder = InvocationRecorder()
 
     override fun <R> access(block: (InvocationRecorder) -> R): R = block(invocationRecorder)
+
+    override fun reset() = invocationRecorder.reset()
 }


### PR DESCRIPTION
Theory: after a mock deallocates, another one can be allocated at exactly the same memory address, leading to calls made to the both mocks being recorded into the same bucket, leading to unexpected verification results.

This probably has something to do with how native allocator works/changed in 1.6.20+ or memory management improvements that lead to faster deallocation of unused objects. Also this seems to be much less likely (impossible?) on JVM.

Note: the current approach with `reset()` won't fix the tests that don't use `runWithTestMode` ❗ 
Ideally, we should either come up with an actually unique key or introduce per-mock call recording, but the latter would require introducing a base mock class unless I'm missing something.