### PR TITLE
Gradle plugin: improve task hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 ---
 
 ## master
+* Make individual test compilation tasks dependent on generateMocks
+* Only require jvmJar instead of assemble to generate mocks
 
 ## 2.4.0
 * Kotlin to 1.6.21

--- a/mockingbird-compiler/src/main/kotlin/com/careem/mockingbird/GradleTasks.kt
+++ b/mockingbird-compiler/src/main/kotlin/com/careem/mockingbird/GradleTasks.kt
@@ -18,6 +18,7 @@ package com.careem.mockingbird
 
 object GradleTasks {
     const val ASSEMBLE = "assemble"
+    const val JVM_JAR = "jvmJar"
     const val GENERATE_MOCKS = "generateMocks"
     const val ALL_TESTS = "allTests"
 }

--- a/mockingbird-compiler/src/main/kotlin/com/careem/mockingbird/MockingbirdPlugin.kt
+++ b/mockingbird-compiler/src/main/kotlin/com/careem/mockingbird/MockingbirdPlugin.kt
@@ -24,6 +24,7 @@ import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.kotlin.dsl.add
 import org.gradle.kotlin.dsl.get
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import java.io.File
 
@@ -54,14 +55,13 @@ abstract class MockingbirdPlugin : Plugin<Project> {
                 EXTENSION_NAME, MockingbirdPluginExtensionImpl(target.objects)
             )
 
-            target.task(GradleTasks.GENERATE_MOCKS) {
-                dependsOn(target.tasks.getByName(GradleTasks.ASSEMBLE))
-                doLast {
-                    generateMocks(target)
-                }
-            }
-
             target.gradle.projectsEvaluated {
+                val generateMocksTask = target.task(GradleTasks.GENERATE_MOCKS) {
+                    dependsOn(target.tasks.getByName(GradleTasks.JVM_JAR))
+                    doLast {
+                        generateMocks(target)
+                    }
+                }
 
                 target.tasks.getByName(GradleTasks.ALL_TESTS) {
                     dependsOn(target.tasks.getByName(GradleTasks.GENERATE_MOCKS))

--- a/mockingbird-compiler/src/main/kotlin/com/careem/mockingbird/MockingbirdPlugin.kt
+++ b/mockingbird-compiler/src/main/kotlin/com/careem/mockingbird/MockingbirdPlugin.kt
@@ -63,8 +63,10 @@ abstract class MockingbirdPlugin : Plugin<Project> {
                     }
                 }
 
-                target.tasks.getByName(GradleTasks.ALL_TESTS) {
-                    dependsOn(target.tasks.getByName(GradleTasks.GENERATE_MOCKS))
+                target.tasks.forEach { task ->
+                    if (task.name.contains("Test") && (task is KotlinCompile)) {
+                        task.dependsOn(generateMocksTask)
+                    }
                 }
 
                 configureSourceSets(target)


### PR DESCRIPTION
Two changes:
* Make individual test compilation tasks dependent on generateMocks
* Only require jvmJar instead of assemble to generate mocks

The former makes invoking `jvmTest`, `iosX64Test` and other platform variants possible without manually running `generateMocks` if `allTests` hasn never been run yet. I have a hunch it should also fix spurious failures we've been observing when using Kotlin 1.6.20+.