### PR TITLE
Clear mocks before regeneration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ---
 
 ## master
+* Fix issue: https://github.com/careem/mockingbird/issues/109
 
 ## 2.5.0
 * Reduce dependencies of `generateMocks` task and make sure mocks are always generated prior to building tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ---
 
 ## master
-* Fix issue: https://github.com/careem/mockingbird/issues/109
+* Fix issue: https://github.com/careem/mockingbird/issues/109, Stale mocks are not always removed.
 
 ## 2.5.0
 * Reduce dependencies of `generateMocks` task and make sure mocks are always generated prior to building tests

--- a/mockingbird-compiler/src/main/kotlin/com/careem/mockingbird/MockingbirdPlugin.kt
+++ b/mockingbird-compiler/src/main/kotlin/com/careem/mockingbird/MockingbirdPlugin.kt
@@ -116,7 +116,7 @@ abstract class MockingbirdPlugin : Plugin<Project> {
         }
     }
 
-    private fun targetOutputDir(target: Project): File{
+    private fun targetOutputDir(target: Project): File {
         return File(target.buildDir.absolutePath + File.separator + "generated" + File.separator + "mockingbird")
     }
 

--- a/mockingbird-compiler/src/main/kotlin/com/careem/mockingbird/MockingbirdPlugin.kt
+++ b/mockingbird-compiler/src/main/kotlin/com/careem/mockingbird/MockingbirdPlugin.kt
@@ -58,6 +58,10 @@ abstract class MockingbirdPlugin : Plugin<Project> {
             target.gradle.projectsEvaluated {
                 val generateMocksTask = target.task(GradleTasks.GENERATE_MOCKS) {
                     dependsOn(target.tasks.getByName(GradleTasks.JVM_JAR))
+                    doFirst {
+                        val outputDir = targetOutputDir(target)
+                        outputDir.deleteRecursively()
+                    }
                     doLast {
                         generateMocks(target)
                     }
@@ -95,8 +99,7 @@ abstract class MockingbirdPlugin : Plugin<Project> {
 
         val pluginExtensions = target.extensions[EXTENSION_NAME] as MockingbirdPluginExtensionImpl
         logger.info("Mocking: ${pluginExtensions.generateMocksFor}")
-        val outputDir =
-            File(target.buildDir.absolutePath + File.separator + "generated" + File.separator + "mockingbird")
+        val outputDir = targetOutputDir(target)
         outputDir.mkdirs()
 
         pluginExtensions.generateMocksFor
@@ -111,6 +114,10 @@ abstract class MockingbirdPlugin : Plugin<Project> {
                 kotlin.srcDir("build/generated/mockingbird")
             }
         }
+    }
+
+    private fun targetOutputDir(target: Project): File{
+        return File(target.buildDir.absolutePath + File.separator + "generated" + File.separator + "mockingbird")
     }
 
 


### PR DESCRIPTION
This patch fix https://github.com/careem/mockingbird/issues/109 ensuring older version of the mock is always removed.