### PR TITLE
Ensure each mock as a unique id even after de-allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Change Log
+
 All notable changes to this project will be documented in this file.
 
 ---
@@ -6,10 +7,16 @@ All notable changes to this project will be documented in this file.
 ## master
 * Fix issue: https://github.com/careem/mockingbird/issues/109, Stale mocks are not always removed.
 
+* **breaking** Fix issue https://github.com/careem/mockingbird/issues/116, if you are generate Mocks manually you need to
+  override `public val uuid: String` like `override val uuid: String by uuid()` if you are using the plugin no changes are
+  required on your side
+
 ## 2.5.0
+
 * Reduce dependencies of `generateMocks` task and make sure mocks are always generated prior to building tests
 
 ## 2.4.0
+
 * Kotlin to 1.6.21
 * Jacoco to 0.8.8
 * AtomicFu to 0.17.2
@@ -18,9 +25,11 @@ All notable changes to this project will be documented in this file.
 * mockk to 1.12.3
 
 ## 2.3.0
+
 * Fix issues #86 and #113
 
 ## 2.2.0
+
 * Kotlin 1.5+ required to use the code generation plugin
 * XCode 12.5.+ now required
 * yarn.lock has been added to VCS
@@ -31,27 +40,34 @@ All notable changes to this project will be documented in this file.
 * Kotlin metadata to 0.2.0
 
 ## 2.1.0
+
 * Fixed issue that was preventing the plugin from been applied in the `plugins` block
 * Converted `build.gradle`s to `build.gradle.kts`
 
 ## 2.0.0
+
 * Upgrade kotlin to 1.5.31 in JsPlugin
 * MockingBird plugin
 
 ## 1.15.0
+
 * Support for iosSimulatorArm64
 * HMPP support
 
 ## 1.14.0
+
 * Added support to capture objects and lists while running a test with LOCAL_THREAD mode
 * **[DEPRECATED]** `Slot()` use `slot()` instead
 * **[DEPRECATED]** `CapturedList()` use `capturedList()` instead
 
 ## 1.13.0
+
 * **breaking** If there are multiple mocked responses matching a mock invocation, the one that was added last will be used
-* Introduced testing mode, before the behavior was always MULTI_THREAD now it is possible to set LOCAL_THREAD mode to avoid argument freeze on mock invocation
+* Introduced testing mode, before the behavior was always MULTI_THREAD now it is possible to set LOCAL_THREAD mode to avoid
+  argument freeze on mock invocation
 
 ## 1.12.0
+
 * Migrating to Gradle Version Catalog and removed Deps
 * Bump gradle to 7.2
 * Upgrade kotlin to 1.5.31
@@ -59,27 +75,32 @@ All notable changes to this project will be documented in this file.
 * Upgrade Stately to 1.1.10-a1
 
 ## 1.11.0
+
 * Enabled warnings as errors
 * Enabled `explictApi()` mode
 * Upgrade kotlin to 1.5.21
 * Upgrade AtomicFu 0.16.2
 
 ## 1.10.0
+
 * Upgrade Kotlin 1.5.10
 
 ## 1.9.0
+
 * Upgrade Kotlin 1.5.0
 * Support for IR compiler
 * Upgrade Stately 1.1.7-a1
 * Upgrade AtomicFu 0.16.1
 
 ## 1.8.0
+
 * Add typed argument getter to Invocation
 * Upgrade Kotlin 1.4.32
 * Upgrade Stately 1.1.6-a1
 * Upgrade AtomicFu 0.15.2
 
 ## 1.7.0
+
 * Upgrade Kotlin 1.4.21
 * Included fix done in version (1.4.1)
 
@@ -96,24 +117,29 @@ All notable changes to this project will be documented in this file.
 * Fixed issue where mocking a dependency was freezing the mock as well
 
 ## 1.4.0
+
 * Added support for timeout during `verify`
 * Added more info when not mocked response
 * Added `CapturedList` class to support capture mutable arguments in `verify` function
 
 ## 1.3.0
+
 * Supporting Javascript for nodeJs without browser
 
 ## 1.2.0
+
 * Added `spy` function to support spy operation
 * Enforced type safety for all function, now you will get type error before runtime if you try to `verify` a non Mock
 
 ## 1.1.0
+
 * Renaming `threadedTest` to `runOnWorker`
 * Adding support for multithreaded tests (experimental, only mock calls are supported from different thread)
 * Fixed Expected , actual reversed
 * Fixed issue where `threadedTest` was running the body twice
 
 ## 1.0.0
+
 * `mockUnit` function
 * `mock` function
 * `every` function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 ---
 
 ## master
-* Fix issue: https://github.com/careem/mockingbird/issues/109, Stale mocks are not always removed.
 
 * **breaking** Fix issue https://github.com/careem/mockingbird/issues/116, if you are generate Mocks manually you need to
   override `public val uuid: String` like `override val uuid: String by uuid()` if you are using the plugin no changes are
   required on your side
+* * Fix issue: https://github.com/careem/mockingbird/issues/109, Stale mocks are not always removed.
 
 ## 2.5.0
 

--- a/mockingbird-compiler/src/main/kotlin/com/careem/mockingbird/MockGenerator.kt
+++ b/mockingbird-compiler/src/main/kotlin/com/careem/mockingbird/MockGenerator.kt
@@ -87,9 +87,6 @@ class MockGenerator constructor(
             mockProperty(mockClassBuilder, property)
         }
 
-
-
-
         return FileSpec.builder(packageName, "${simpleName}Mock")
             .addType(mockClassBuilder.build())
             .build()

--- a/mockingbird-compiler/src/main/kotlin/com/careem/mockingbird/MockGenerator.kt
+++ b/mockingbird-compiler/src/main/kotlin/com/careem/mockingbird/MockGenerator.kt
@@ -25,6 +25,7 @@ import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.asTypeName
+import com.squareup.kotlinpoet.buildCodeBlock
 import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
 import com.squareup.kotlinpoet.metadata.isNullable
 import com.squareup.kotlinpoet.metadata.isSuspend
@@ -71,9 +72,23 @@ class MockGenerator constructor(
             mockFunction(mockClassBuilder, function, isUnitFunction(function))
         }
 
+        val uuid = PropertySpec.builder("uuid", String::class, KModifier.OVERRIDE)
+            .addModifiers(KModifier.PUBLIC)
+            .delegate(
+                buildCodeBlock {
+                    val uuid = MemberName("com.careem.mockingbird.test", "uuid")
+                    add("%M()", uuid)
+                })
+            .build()
+
+        mockClassBuilder.addProperty(uuid)
+
         propertiesToMock.forEach { property ->
             mockProperty(mockClassBuilder, property)
         }
+
+
+
 
         return FileSpec.builder(packageName, "${simpleName}Mock")
             .addType(mockClassBuilder.build())
@@ -245,7 +260,7 @@ class MockGenerator constructor(
     @OptIn(ExperimentalStdlibApi::class)
     private fun buildFunctionModifiers(
         function: KmFunction
-    ) : List<KModifier> {
+    ): List<KModifier> {
         return buildList {
             add(KModifier.OVERRIDE)
             if (function.isSuspend) {

--- a/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/InvocationRecorder.kt
+++ b/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/InvocationRecorder.kt
@@ -22,72 +22,72 @@ internal class InvocationRecorder {
         ensureNeverFrozen()
     }
 
-    private val recorder = mutableMapOf<Int, MutableList<Invocation>>()
-    private val responses = mutableMapOf<Int, LinkedHashMap<Invocation, (Invocation) -> Any?>>()
+    private val recorder = mutableMapOf<String, MutableList<Invocation>>()
+    private val responses = mutableMapOf<String, LinkedHashMap<Invocation, (Invocation) -> Any?>>()
 
     /**
      * This function must be called by the mock when a function call is exceuted on it
-     * @param instanceHash the instanceHash of the mock
+     * @param uuid the uuid of the mock
      * @param invocation the Invocation object @see [Invocation]
      */
-    fun storeInvocation(instanceHash: Int, invocation: Invocation) {
-        if (!recorder.containsKey(instanceHash)) {
-            recorder[instanceHash] = mutableListOf()
+    fun storeInvocation(uuid: String, invocation: Invocation) {
+        if (!recorder.containsKey(uuid)) {
+            recorder[uuid] = mutableListOf()
         }
-        recorder[instanceHash]!!.add(invocation)
+        recorder[uuid]!!.add(invocation)
     }
 
     /**
      * This function returns the list of invocations registered for a certain mock
-     * @param instanceHash the instanceHash of the mock
+     * @param uuid the uuid of the mock
      * @return list of [Invocation]s object (all the methods calls with args)
      */
-    internal fun getInvocations(instanceHash: Int): List<Invocation> {
-        return recorder[instanceHash] ?: emptyList()
+    internal fun getInvocations(uuid: String): List<Invocation> {
+        return recorder[uuid] ?: emptyList()
     }
 
     /**
      * This function tells to InvocationRecorder how to reply if invocation is received
-     * @param instanceHash the instanceHash of the mock
+     * @param uuid the uuid of the mock
      * @param invocation the Invocation object @see [Invocation]
      * @param response the object that must be returned if the specif invocation happen
      */
-    fun <T> storeResponse(instanceHash: Int, invocation: Invocation, response: T) {
+    fun <T> storeResponse(uuid: String, invocation: Invocation, response: T) {
         val answer: (Invocation) -> T = { _ -> response }
-        storeAnswer(instanceHash, invocation, answer)
+        storeAnswer(uuid, invocation, answer)
     }
 
     /**
      * This function tells to InvocationRecorder how to reply if invocation is received
-     * @param instanceHash the instanceHash of the mock
+     * @param uuid the uuid of the mock
      * @param invocation the Invocation object @see [Invocation]
      * @param answer the lambda that must be invoked when the invocation happen
      */
-    fun <T> storeAnswer(instanceHash: Int, invocation: Invocation, answer: (Invocation) -> T) {
-        if (!responses.containsKey(instanceHash)) {
-            responses[instanceHash] = LinkedHashMap()
+    fun <T> storeAnswer(uuid: String, invocation: Invocation, answer: (Invocation) -> T) {
+        if (!responses.containsKey(uuid)) {
+            responses[uuid] = LinkedHashMap()
         }
-        responses[instanceHash]!![invocation] = answer as (Invocation) -> Any?
+        responses[uuid]!![invocation] = answer as (Invocation) -> Any?
     }
 
     /**
      * This function will return the mocked response previously stored for the specific invocation
-     * @param instanceHash the instanceHash of the mock
+     * @param uuid the uuid of the mock
      * @param invocation the Invocation object @see [Invocation]
      * @param relaxed specify if we want to crash when no mock behavior provided
      * @throws IllegalStateException if no response was stored for the instance and invocation
      * @return the mocked response, or null if relaxed (throws if not relaxed)
      */
-    fun getResponse(instanceHash: Int, invocation: Invocation, relaxed: Boolean = false): Any? {
-        return if (instanceHash in responses.keys) {
-            responses[instanceHash]!!.let {
+    fun getResponse(uuid: String, invocation: Invocation, relaxed: Boolean = false): Any? {
+        return if (uuid in responses.keys) {
+            responses[uuid]!!.let {
                 val lambda = findResponseByInvocation(it, invocation, relaxed)
                 return@let lambda(invocation)
             }
         } else if (relaxed) {
             null
         } else {
-            throw IllegalStateException("Not mocked response for current object and instance, instance:$instanceHash, invocation: $invocation")
+            throw IllegalStateException("Not mocked response for current object and instance, instance:$uuid, invocation: $invocation")
         }
     }
 

--- a/mockingbird/src/commonTest/kotlin/com/careem/mockingbird/test/InvocationRecorderTest.kt
+++ b/mockingbird/src/commonTest/kotlin/com/careem/mockingbird/test/InvocationRecorderTest.kt
@@ -58,7 +58,7 @@ class InvocationRecorderTest {
     }
 
     @Test
-    fun testUuuid() {
+    fun testUuidGeneration() {
         val mock = Mocks.MyDependencyMock()
         val uuid = mock.uuid
         assertEquals(uuid, mock.uuid)

--- a/mockingbird/src/commonTest/kotlin/com/careem/mockingbird/test/InvocationRecorderTest.kt
+++ b/mockingbird/src/commonTest/kotlin/com/careem/mockingbird/test/InvocationRecorderTest.kt
@@ -178,7 +178,7 @@ class InvocationRecorderTest {
             invocationRecorder.getResponse(mock.uuid, invocation1)
         } catch (ise: IllegalStateException) {
             e = ise
-            assertEquals("Not mocked response for current object and instance, instance:${mock.hashCode()}, invocation: $invocation1", e.message)
+            assertEquals("Not mocked response for current object and instance, instance:${mock.uuid}, invocation: $invocation1", e.message)
         }
         assertNotNull(e)
     }

--- a/mockingbird/src/commonTest/kotlin/com/careem/mockingbird/test/InvocationRecorderTest.kt
+++ b/mockingbird/src/commonTest/kotlin/com/careem/mockingbird/test/InvocationRecorderTest.kt
@@ -81,7 +81,7 @@ class InvocationRecorderTest {
 
     @Test
     fun testInvocationsStoredProperlyForMultipleInstancesOfSameMock() {
-        val iterations = 1000000
+        val iterations = 100000
         val invocation1 = Invocation(METHOD_1, ARGS_1)
         val uuid = mutableSetOf<String>()
 

--- a/mockingbird/src/commonTest/kotlin/com/careem/mockingbird/test/Mocks.kt
+++ b/mockingbird/src/commonTest/kotlin/com/careem/mockingbird/test/Mocks.kt
@@ -50,6 +50,8 @@ object Mocks {
             const val callback = "callback"
         }
 
+        override val uuid: String by uuid()
+
         override fun method1(str: String) = mockUnit(
             methodName = Method.method1,
             arguments = mapOf(
@@ -107,6 +109,8 @@ object Mocks {
             const val value2 = "value2"
             const val callback = "callback"
         }
+
+        override val uuid: String by uuid()
 
         override fun method1(str: String) = spy(
             methodName = Method.method1,

--- a/samples/sample/src/commonTest/kotlin/com/careem/mockingbird/sample/Sample.kt
+++ b/samples/sample/src/commonTest/kotlin/com/careem/mockingbird/sample/Sample.kt
@@ -18,7 +18,9 @@ package com.careem.mockingbird.sample
 
 import com.careem.mockingbird.common.sample.ExternalContractMock
 import com.careem.mockingbird.common.sample.ExternalDepMock
+import com.careem.mockingbird.test.verify
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 class TestClass {
@@ -27,6 +29,22 @@ class TestClass {
     fun testGeneratedTargetProjectMock() {
         val pippoMock: PippoSample = PippoSampleMock()
         assertNotNull(pippoMock)
+    }
+
+    @Test
+    fun testInvocationsStoredProperlyForMultipleInstancesOfSameGeneratedMock() {
+        val iterations = 100
+        val uuids = mutableSetOf<String>()
+
+        (0 until iterations).forEach {
+            val mock = PippoSampleMock()
+            uuids.add(mock.uuid)
+            mock.sayHi()
+            mock.verify(
+                methodName = PippoSampleMock.Method.sayHi,
+            )
+        }
+        assertEquals(iterations, uuids.size)
     }
 
     @Test


### PR DESCRIPTION
This patch fix https://github.com/careem/mockingbird/issues/116 ensuring that even if a mock is deallocated it uuid is unique across the whole process lifecycle

TODO:
- [x] Validate this change further within internal library