### PR TITLE
Include visibility to generated mock

### DIFF
--- a/samples/sample/build.gradle.kts
+++ b/samples/sample/build.gradle.kts
@@ -43,6 +43,7 @@ configure<com.careem.mockingbird.MockingbirdPluginExtension> {
         "com.careem.mockingbird.sample.JavaTypes",
         "com.careem.mockingbird.sample.InterfaceWithGenerics",
         "com.careem.mockingbird.sample.PippoSample",
+        "com.careem.mockingbird.sample.InternalSampleInterface",
         "com.careem.mockingbird.sample.LambdaSample",
         "com.careem.mockingbird.sample.Mock1",
         "com.careem.mockingbird.sample.MockWithExternalDependencies",

--- a/samples/sample/src/commonMain/kotlin/com/careem/mockingbird/sample/InternalSampleInterface.kt
+++ b/samples/sample/src/commonMain/kotlin/com/careem/mockingbird/sample/InternalSampleInterface.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright Careem, an Uber Technologies Inc. company
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.careem.mockingbird.sample
+
+internal interface InternalSampleInterface {
+    fun thisIsInternal(param: String)
+}

--- a/samples/sample/src/commonTest/kotlin/com/careem/mockingbird/sample/Sample.kt
+++ b/samples/sample/src/commonTest/kotlin/com/careem/mockingbird/sample/Sample.kt
@@ -82,5 +82,11 @@ class TestClass {
         val mock = ExternalDepMock()
         assertNotNull(mock)
     }
+
+    @Test
+    fun testGeneratedInternalClass() {
+        val mock = InternalSampleInterfaceMock()
+        assertNotNull(mock)
+    }
 }
 


### PR DESCRIPTION
## Description
Currently if we have a class with internal visibility, the generated mock will still generate it with public visibility

Fixing by checking visibility and adding it to class builder