### PR TITLE
Support Mock generation for generic interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ---
 
 ## master
+* Support mock generation for interfaces with generics
 
 ## 2.7.0
 * MockingBird plugin support ksp codegen out of the box of google ksp plugin is applied

--- a/samples/kspsample/src/commonMain/kotlin/com/careem/mockingbird/kspsample/Generics2Args.kt
+++ b/samples/kspsample/src/commonMain/kotlin/com/careem/mockingbird/kspsample/Generics2Args.kt
@@ -1,0 +1,15 @@
+package com.careem.mockingbird.kspsample
+
+import kotlin.reflect.KClass
+
+public interface Value
+
+public interface UiDelegate2Args<S : UiState, T: Value> {
+    var s: S
+    val t: T
+
+    public fun present(uiState: S)
+    public fun present(uiState: T)
+    public fun remove(uiStateType: KClass<out UiState>)
+    public fun ret(): S
+}

--- a/samples/kspsample/src/commonMain/kotlin/com/careem/mockingbird/kspsample/UiDelegate.kt
+++ b/samples/kspsample/src/commonMain/kotlin/com/careem/mockingbird/kspsample/UiDelegate.kt
@@ -1,0 +1,14 @@
+package com.careem.mockingbird.kspsample
+
+import kotlin.reflect.KClass
+
+public interface UiState
+
+public interface UiDelegate<S : UiState> {
+    var s: S
+    val t: S
+
+    public fun present(uiState: S)
+    public fun remove(uiStateType: KClass<out UiState>)
+    public fun ret(): S
+}

--- a/samples/kspsample/src/commonTest/kotlin/com/careem/mockingbird/kspsample/KspSampleTest.kt
+++ b/samples/kspsample/src/commonTest/kotlin/com/careem/mockingbird/kspsample/KspSampleTest.kt
@@ -54,6 +54,12 @@ class KspSampleTest {
     @Mock
     val innerInnerInterface: InnerInnerInterface = InnerInnerInterfaceMock()
 
+    @Mock
+    val uiDelegate: UiDelegate<UiState> = UiDelegate_UiStateMock()
+
+    @Mock
+    val uiDelegate2Args: UiDelegate2Args<UiState, Value> = UiDelegate2Args_UiState_ValueMock()
+
     @Test
     fun testGeneratedTargetProjectMock() {
         assertNotNull(pippoMock)


### PR DESCRIPTION
This patch allow you to mock classes like `MyInterface<MyType>` the generated mock will have the following naming `MyInterface_MyTypeMock`