### PR TITLE
Fix ksp code generation for non-jvm target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ---
 ## master
+* Fix ksp code generation for non-jvm target
 
 ## 2.13.0
 * Refactoring publication and configuration logic


### PR DESCRIPTION
When jvm isn't a target, ksp code generation fails due to the wrong srcDir being generated and the wrong dependency and task being set