### PR TITLE
Fix concurrent invocations of InvocationRecorder

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -105,7 +105,6 @@
                   <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
                 </AND>
               </match>
-              <order>ANDROID_ATTRIBUTE_ORDER</order>
             </rule>
           </section>
           <section>

--- a/mockingbird/build.gradle.kts
+++ b/mockingbird/build.gradle.kts
@@ -36,9 +36,16 @@ kotlin {
                 implementation(libs.touchlab.stately.concurrency)
                 implementation(libs.touchlab.stately.concurrent.collections)
                 implementation(libs.kotlinx.coroutines)
-                implementation(libs.kotlin.test)
             }
         }
+
+        val commonTest by getting {
+            dependencies {
+                implementation(libs.kotlin.test)
+                implementation(libs.kotlinx.coroutines.test)
+            }
+        }
+
         val iosMain by getting
         val iosSimulatorArm64Main by getting {
             dependsOn(iosMain)

--- a/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/Functions.kt
+++ b/mockingbird/src/commonMain/kotlin/com/careem/mockingbird/test/Functions.kt
@@ -18,14 +18,10 @@ package com.careem.mockingbird.test
 
 import kotlinx.atomicfu.AtomicInt
 import kotlinx.atomicfu.atomic
-import kotlin.native.concurrent.SharedImmutable
-import kotlin.test.assertEquals
 
 
-@SharedImmutable
 internal const val AWAIT_POOLING_TIME = 10L
 
-@SharedImmutable
 private val uuidGenerator: AtomicInt = atomic(0)
 
 public interface Mock {
@@ -148,6 +144,16 @@ internal fun <T : Mock> T.rawVerify(
             found: $methodInvocations
         """.trimIndent()
         )
+    }
+}
+
+private fun assertEquals(
+    expected: Int,
+    actual: Int,
+    message: String
+) {
+    if (expected != actual) {
+        throw AssertionError(message)
     }
 }
 

--- a/versions.toml
+++ b/versions.toml
@@ -6,7 +6,7 @@ kotlin = "1.9.10"
 kspVersion = "1.9.10-1.0.13"
 junit = "4.13.1"
 jacoco = "0.8.10"
-stately = "2.0.0-rc3"
+stately = "2.0.5"
 atomicFu = "0.22.0"
 kotlinPoet = "1.14.2"
 kotlinxMetadata = "0.7.0"
@@ -20,6 +20,7 @@ touchlab-stately-concurrency = { module = "co.touchlab:stately-concurrency", ver
 touchlab-stately-concurrent-collections = { module = "co.touchlab:stately-concurrent-collections", version.ref = "stately" }
 kotlinx-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicFu" }
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-test-common = { module = "org.jetbrains.kotlin:kotlin-test-common", version.ref = "kotlin" }
 kotlin-test-annotations = { module = "org.jetbrains.kotlin:kotlin-test-annotations-common", version.ref = "kotlin" }


### PR DESCRIPTION
`recorder` and `responses` maps access where not threadsafe